### PR TITLE
Improve installation guide...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,11 @@ FROM rocker/shiny:3.4.4
 LABEL repository="https://github.com/NEONKID/RCDMViewer"
 LABEL homepage="https://neonkid.xyz"
 LABEL maintainer="Neon K.I.D <contact@neonkid.xyz>"
-LABEL version="0.1"
 
 WORKDIR /srv/shiny-server
 
 RUN apt-get update
-RUN apt-get install -y libxml2-dev libssl-dev default-jdk default-jre libbz2-dev libpcre3-dev liblzma-dev libjpeg-dev libgeos-dev 
+RUN apt-get install -y libxml2-dev libssl-dev default-jdk default-jre libbz2-dev libicu-dev libpcre3-dev liblzma-dev libjpeg-dev libgeos-dev 
 
 RUN mkdir -p RCDMViewer
 ADD ./RCDMviewer.cfg /srv/shiny-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# OS: Debian Linux
+FROM rocker/shiny:3.4.4
+
+# This container information
+LABEL repository="https://github.com/NEONKID/RCDMViewer"
+LABEL homepage="https://neonkid.xyz"
+LABEL maintainer="Neon K.I.D <contact@neonkid.xyz>"
+LABEL version="0.1"
+
+WORKDIR /srv/shiny-server
+
+RUN apt-get update
+RUN apt-get install -y libxml2-dev libssl-dev default-jdk default-jre libbz2-dev libpcre3-dev liblzma-dev libjpeg-dev libgeos-dev 
+
+RUN mkdir -p RCDMViewer
+ADD ./RCDMviewer.cfg /srv/shiny-server
+ADD ./R /srv/shiny-server/RCDMViewer
+RUN Rscript RCDMViewer/packageManager.R
+
+CMD ["/usr/bin/shiny-server.sh"]

--- a/R/packageManager.R
+++ b/R/packageManager.R
@@ -1,0 +1,17 @@
+# rocker container default repo is mran.microsoft.com
+options(repos=structure(c(CRAN="http://cloud.r-project.org/")))
+
+check.packages <- function(pkg) {
+    new.pkg <- pkg[!(pkg %in% installed.packages()[, "Package"])]
+    if(length(new.pkg))
+        install.packages(new.pkg, dependencies = TRUE)
+    sapply(pkg, require, character.only = TRUE)
+}
+
+need_pkg <- c('units', 'xml2', 'openssl', 'httr', 'binman', 
+              'devtools', 'oro.dicom', 'oro.nifti', 'neurobase', 'shinythemes', 
+              'shinyWidgets', 'shinyBS', 'shinycssloaders', 'plotly')
+check.packages(need_pkg)
+
+if(!require('RadETL'))
+    devtools::install_github('OHDSI/Radiology-CDM')

--- a/R/packageManager.R
+++ b/R/packageManager.R
@@ -8,10 +8,10 @@ check.packages <- function(pkg) {
     sapply(pkg, require, character.only = TRUE)
 }
 
-need_pkg <- c('units', 'xml2', 'openssl', 'httr', 'binman', 
-              'devtools', 'oro.dicom', 'oro.nifti', 'neurobase', 'shinythemes', 
-              'shinyWidgets', 'shinyBS', 'shinycssloaders', 'plotly')
-check.packages(need_pkg)
+req_pkg <- c('xml2', 'openssl', 'httr', 'binman', 'devtools',           # Basic required packages
+              'oro.dicom', 'oro.nifti', 'neurobase', 'shinythemes',     # Server required packages
+              'shinyWidgets', 'shinyBS', 'shinycssloaders', 'plotly')   # UI required packages
+check.packages(req_pkg)
 
 if(!require('RadETL'))
     devtools::install_github('OHDSI/Radiology-CDM')

--- a/R/server.R
+++ b/R/server.R
@@ -1,6 +1,5 @@
-library('RadETL')
-need_server <- c('oro.dicom', 'oro.nifti', 'neurobase')
-lapply(need_server, library, character.only = TRUE)
+im_pkg <- c('oro.dicom', 'oro.nifti', 'neurobase', 'RadETL')
+lapply(im_pkg, library, character.only = TRUE)
 
 options(niftiAuditTrail = TRUE)
 

--- a/R/server.R
+++ b/R/server.R
@@ -1,7 +1,6 @@
 library('RadETL')
-library('oro.dicom')
-library('oro.nifti')
-library('neurobase')
+need_server <- c('oro.dicom', 'oro.nifti', 'neurobase')
+lapply(need_server, library, character.only = TRUE)
 
 options(niftiAuditTrail = TRUE)
 
@@ -176,9 +175,11 @@ server <- function(input, output, session) {
         })
         try(val_den <- density(niftiVolume()))
         plot_ly(x = ~val_den$x, y = ~val_den$y, type = 'scatter', mode = 'lines', fill = 'tozeroy', 
-                fillcolor = 'rgba(30, 136, 229, 0.5)', line = list(width = 1.0)) %>%
-            layout(xaxis = list(title = paste0('N = ', val_den$n, ', Bandwidth = ', val_den$bw)),
-                   yaxis = list(title = 'Density'))
+                fillcolor = 'rgba(30, 136, 229, 0.5)', line = list(simplyfy = FALSE, width = 1.0)) %>%
+            layout(xaxis = list(title = paste0('N = ', val_den$n, ', Bandwidth = ', val_den$bw), zeroline = FALSE),
+                   yaxis = list(title = 'Density', zeroline = FALSE)) %>%
+            animation_opts(frame = 100, transition = 0, redraw = TRUE) %>%
+            animation_slider(hide = TRUE)
     })
     
     #

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,8 +1,5 @@
-library(shinythemes)
-library(shinyWidgets)
-library(shinyBS)
-library(shinycssloaders)
-library(plotly)
+need_ui <- c('shinythemes', 'shinyWidgets', 'shinyBS', 'shinycssloaders', 'plotly')
+lapply(need_ui, library, character.only = TRUE)
 
 source('tabs.R')
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,5 +1,5 @@
-need_ui <- c('shinythemes', 'shinyWidgets', 'shinyBS', 'shinycssloaders', 'plotly')
-lapply(need_ui, library, character.only = TRUE)
+im_pkg <- c('shinythemes', 'shinyWidgets', 'shinyBS', 'shinycssloaders', 'plotly')
+lapply(im_pkg, library, character.only = TRUE)
 
 source('tabs.R')
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,6 @@ See this link for more information on [RCDM](https://github.com/OHDSI/Radiology-
 
 
 
-## Preview (image)
-
-![Radiology_Image](images/preview-image.gif)
-
-
-
-## Preview (Occurrence)
-
-![Radiology_Occurrence](images/preview-occurrence.gif)
-
-
-
 ## How to install
 
 This application must ETL the current user's radiology image in RCDM format, and this viewer will not work when reading normal radiation image.
@@ -37,6 +25,18 @@ git clone https://github.com/NEONKID/RCDMViewer.git
 ```
 
 If Clone is finished, create RDBMS connection information with RCDM in the configuration file named RCDMViewer.cfg. ***If you do not create this file, you will not be able to use the application.***
+
+
+
+### Using Host
+
+If you want to distribute RCDMViewer directly to the host, you can distribute it using Shiny Server. But before that you need to install the necessary packages for RCDMViewer.
+
+```bash
+Rscript packageManager.R
+```
+
+The packageManager.R code is the code that installs these packages.
 
 
 
@@ -54,5 +54,11 @@ By default, the Shiny server uses port 3838. If you want to distribute it to the
 docker run --name rcdmviewer -d -p 3838:3838 rcdmviewer:latest
 ```
 
+
+
+## Preview 
+
+![Radiology_Image](images/preview-image.gif)
+![Radiology_Occurrence](images/preview-occurrence.gif)
 
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ By default, the Shiny server uses port 3838. If you want to distribute it to the
 docker run --name rcdmviewer -d -p 3838:3838 rcdmviewer:latest
 ```
 
+I recommend using docker-compose. If you want to upload RCDMViewer with a simple command, you can use the above command, but if you want to use log or the like as a storage of host or to put RCDM in container, you have to call several containers.
+
+In general, the web uses 80 ports as the default port, so I connected it to 80 ports.
+(See the docker-compose.yml file for details)
+
+```bash
+docker-compose up
+```
+
+
+
 
 
 ## Preview 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See this link for more information on [RCDM](https://github.com/OHDSI/Radiology-
 
 
 
-## How to use
+## How to install
 
 This application must ETL the current user's radiology image in RCDM format, and this viewer will not work when reading normal radiation image.
 
@@ -37,4 +37,22 @@ git clone https://github.com/NEONKID/RCDMViewer.git
 ```
 
 If Clone is finished, create RDBMS connection information with RCDM in the configuration file named RCDMViewer.cfg. ***If you do not create this file, you will not be able to use the application.***
+
+
+
+### Using Docker
+
+The repository contains a Dockerfile with version 3.4.4. RCDMViewer is more than R version 3.4.4, so if you want to use another version, you can modify Dockerfile.
+
+```bash
+docker build --tag rcdmviewer:latest .
+```
+
+By default, the Shiny server uses port 3838. If you want to distribute it to the outside world, use the following command.
+
+```bash
+docker run --name rcdmviewer -d -p 3838:3838 rcdmviewer:latest
+```
+
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+services:
+  rcdmviewer:
+    container_name: rcdmviewer
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '80:3838'


### PR DESCRIPTION
**Use the Docker to improve the installation method of RCDMViewer.**
- I used rocker / shiny: 3.4.4 as the base base image and minimum version 3.4.4 version
- Use the lapply and sapply functions to simplify functions that are used repeatedly